### PR TITLE
Change request to node-fetch and make images return buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
-const request = require('request');
+const fetch = require('node-fetch');
 const {URL, URLSearchParams} = require('url');
 const endpoints = require('./endpoints.json');
-function getContent(url, key) {
-  return new Promise((resolve, reject) => {
-    request({
-      headers:{
+async function getContent(url, key, image) {
+  try {
+    const res = await fetch(url, {
+      headers: {
         'Authorization': key,
         'User-Agent': 'AlexFlipnote.js@2.0.0 by HarutoHiroki#4000' 
-      },
-      url: url,
-      method: 'GET'
-    }, function (err, res, body) {
-      if(err) reject(`Error: ${err}`);
-      resolve(JSON.parse(res.body));
-    })
-  })
+      }
+    });
+    return image ? await res.buffer() : res.json();
+  }
+  catch (e) {
+    return `Error: ${e}`;
+  }
 }
 
 class AlexClient {
@@ -25,19 +24,19 @@ class AlexClient {
     let baseURL = 'https://api.alexflipnote.dev';
     Object.keys(endpoints.image).forEach(async (endpoint) => {
       self.image[endpoint] = async function (queryParams = '') {
-        let url = new URL(`${baseURL}${endpoints.image[endpoint]}`);
-        queryParams !== '' ? url.search = new URLSearchParams(queryParams) : '';
-        return await getContent(url.toString(), key);
+          let url = new URL(`${baseURL}${endpoints.image[endpoint]}`);
+          queryParams !== '' ? url.search = new URLSearchParams(queryParams) : '';
+          return await getContent(url.toString(), key, true);
         };
     });
-    Object.keys(endpoints.others).forEach( async (endpoint) => {
+    Object.keys(endpoints.others).forEach(async (endpoint) => {
       self.others[endpoint] = async function (params = '') {
         let url = new URL(`${baseURL}${endpoints.others[endpoint]}`);
-        if(endpoints.others[endpoint].includes("color")){
-          if(/^[0-9A-F]{6}$/i.test(params.toUpperCase())){
-            url = url.toString()+params
+        if (endpoints.others[endpoint].includes("color")) {
+          if (/^[0-9A-F]{6}$/i.test(params.toUpperCase())) {
+            url = url.toString() + params
             return await getContent(url, key);
-          }else{
+          } else {
             return console.error("Not a valid hex value")
           }
         }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function getContent(url, key, image) {
         'User-Agent': 'AlexFlipnote.js@2.0.0 by HarutoHiroki#4000' 
       }
     });
-    return image ? res.buffer() : res.json();
+    return image ? await res.buffer() : await res.json();
   }
   catch (e) {
     return `Error: ${e}`;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function getContent(url, key, image) {
         'User-Agent': 'AlexFlipnote.js@2.0.0 by HarutoHiroki#4000' 
       }
     });
-    return image ? await res.buffer() : res.json();
+    return image ? res.buffer() : res.json();
   }
   catch (e) {
     return `Error: ${e}`;

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/HarutoHiroki/alexflipnote.js/issues"
   },
-  "homepage": "https://github.com/HarutoHiroki/alexflipnote.js#readme"
+  "homepage": "https://github.com/HarutoHiroki/alexflipnote.js#readme",
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  }
 }


### PR DESCRIPTION
1. Changed request (deprecated) to node-fetch.
2. Images now return buffers instead of a parse error.

Other files including typings were untouched.